### PR TITLE
[QA-157]: Remove existing permissions boundary

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -6,11 +6,6 @@ Description: >
   Performance Testing Framework for Load Testing
 
 Conditions:
-  UsePermissionsBoundary:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref PermissionsBoundary
-          - "none"
   CreateVPCConfigurationForTestContainer:
     !Equals [!Ref RunTestContainerInVPC, "True"]
 
@@ -21,10 +16,6 @@ Parameters:
     AllowedValues:
       - build
       - staging
-  PermissionsBoundary:
-    Description: "The ARN of the permissions boundary to apply when creating IAM roles"
-    Type: String
-    Default: "none"
   RunTestContainerInVPC:
     Description: |
       (Optional)
@@ -57,12 +48,6 @@ Resources:
               - "sts:AssumeRole"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess
-      PermissionsBoundary:
-        !If [
-          UsePermissionsBoundary,
-          !Ref PermissionsBoundary,
-          !Ref AWS::NoValue,
-        ]
 
   CodeBuildServicePolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
Following changes have been done

- Removed references of the existing PermissionsBoundary from the CF template.

Ticket on Bravo side - **ATB-452**
