### PR TITLE
[QA-159]: Add wait time post test and debug logging for OTEL

### DIFF
--- a/deploy/otel-config-template.yaml
+++ b/deploy/otel-config-template.yaml
@@ -15,18 +15,18 @@ processors:
 
   metricstransform:
     transforms:
-    - include: ^.*$
-      match_type: regexp
-      action: update
-      operations:
-        - action: add_label
-          new_label: build_id
-          new_value: "{ID}"
-    - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
-      match_type: regexp
-      action: combine
-      new_name: k6.checks
-      submatch_case: lower
+      - include: ^.*$
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: build_id
+            new_value: "{ID}"
+      - include: ^k6\.check\.(?P<name>.*?)\.(?P<result>.*)
+        match_type: regexp
+        action: combine
+        new_name: k6.checks
+        submatch_case: lower
 
 exporters:
   otlphttp:
@@ -35,9 +35,11 @@ exporters:
       Authorization: "Api-Token {APITOKEN}"
 
 service:
+  telemetry:
+    logs:
+      level: "debug"
 
   pipelines:
-
     metrics:
       receivers: [statsd, hostmetrics]
       processors: [batch, metricstransform]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -468,9 +468,12 @@ Resources:
                 - k6 run $WORK_DIR/$TEST_SCRIPT --tag script=$TEST_SCRIPT --tag account_id=${AWS::AccountId} --out statsd
             post_build:
               commands:
+                - echo Wait 5 minutes to flush remaining metrics
+                - sleep 300
                 - end=`date +"%Y-%m-%dT%H:%M:%SZ"`
                 - |
                   echo "Dashboard link: /#dashboard;gtf="$start"%20to%20"$end";id="$K6_DYNATRACE_DASHBOARD_ID";gf=all;es=CUSTOM_DIMENSION-build_id:"$CODEBUILD_BUILD_ID
+                - cat otel.log
                 - echo Performance test complete
 
       Tags:


### PR DESCRIPTION
Following changes have been done

- Enabled debug OTEL logging 
- Added sleep time of 5 minutes post test to flush metrics to Dynatrace